### PR TITLE
Send and receive ExtraData; validate fp_hash by checking extra return fields;

### DIFF
--- a/src/Message/PurchaseRequest.php
+++ b/src/Message/PurchaseRequest.php
@@ -85,6 +85,7 @@ class PurchaseRequest extends AbstractRequest
             'email' => $card->getEmail(),
             'phone' => $card->getPhone(),
             'fax' => $card->getFax(),
+            'ExtraData'  => $this->getParameter('ExtraData'),
         ];
     }
 

--- a/src/Message/Traits/CompletePurchaseRequestTrait.php
+++ b/src/Message/Traits/CompletePurchaseRequestTrait.php
@@ -13,6 +13,19 @@ trait CompletePurchaseRequestTrait
 {
     use GatewayNotificationRequestTrait;
 
+    public $fields = [
+        'amount',
+        'curr',
+        'invoice_id',
+        'ep_id',
+        'merch_id',
+        'action',
+        'message',
+        'approval',
+        'timestamp',
+        'nonce',
+    ];
+
     /**
      * @return mixed
      */
@@ -39,18 +52,7 @@ trait CompletePurchaseRequestTrait
     public function generateHashString()
     {
         $return = "";
-        $fields = [
-            'amount',
-            'curr',
-            'invoice_id',
-            'ep_id',
-            'merch_id',
-            'action',
-            'message',
-            'approval',
-            'timestamp',
-            'nonce',
-        ];
+        $fields = $this->fields;
         foreach ($fields as $f) {
             $d = addslashes(trim($this->httpRequest->request->get($f)));
             $return .= Helper::generateHashFromString($d);

--- a/src/Traits/HasIntegrationParametersTrait.php
+++ b/src/Traits/HasIntegrationParametersTrait.php
@@ -39,4 +39,13 @@ trait HasIntegrationParametersTrait
     {
         return $this->getParameter('key');
     }
+
+    public function setExtraData($value) {
+        return $this->setParameter('ExtraData', $value);
+    }
+
+    public function getExtraData()
+    {
+        return $this->getParameter('ExtraData');
+    }
 }


### PR DESCRIPTION
1. allow setting and receiving custom data in the ExtraData variable
2. in custom implementation, the completion response request fp_hash may contain some additional fields, such as the first and the last digits of the credit card.

```
$gateway = Omnipay::create('\ByTIC\Omnipay\Euplatesc\Gateway');
$data        = $request->toArray();
$data['key'] = config('euplatesc.key');
$req = $gateway()->completePurchase($data);
$req->fields = array_merge(
  $req->fields, [
    'mcard',
    'bin',
]);
$response    = $req->send();
```